### PR TITLE
lock dockerfile versions to ubuntu 16.04

### DIFF
--- a/Dockerfile.hostapd
+++ b/Dockerfile.hostapd
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 ENV OVSV="2.7.3"
 


### PR DESCRIPTION
latest is now 18.04 and there are packages that break